### PR TITLE
Numba energy permutation test

### DIFF
--- a/dcor/__init__.py
+++ b/dcor/__init__.py
@@ -25,7 +25,7 @@ from ._dcor_internals import (double_centered, u_centered,  # noqa
                               mean_product, u_product,
                               u_projection,
                               u_complementary_projection)
-from ._energy import energy_distance  # noqa
+from ._energy import energy_distance, EstimationStatistic  # noqa
 from ._partial_dcor import (partial_distance_covariance,  # noqa
                             partial_distance_correlation)
 from ._rowwise import rowwise, RowwiseMode

--- a/dcor/_dcor.py
+++ b/dcor/_dcor.py
@@ -625,7 +625,7 @@ def u_distance_stats_sqr(x, y, *, exponent=1,
     variance_x=42.6666666..., variance_y=42.6666666...)
     >>> dcor.u_distance_stats_sqr(a, b) # doctest: +ELLIPSIS
     ...                     # doctest: +NORMALIZE_WHITESPACE
-    Stats(covariance_xy=-2.6666666..., correlation_xy=-0.5,
+    Stats(covariance_xy=-2.6666666..., correlation_xy=-0.4999999...,
     variance_x=42.6666666..., variance_y=0.6666666...)
     >>> dcor.u_distance_stats_sqr(b, b) # doctest: +ELLIPSIS
     ...                     # doctest: +NORMALIZE_WHITESPACE
@@ -822,7 +822,7 @@ def u_distance_correlation_sqr(x, y, *, exponent=1,
     >>> dcor.u_distance_correlation_sqr(a, a)
     1.0
     >>> dcor.u_distance_correlation_sqr(a, b)
-    -0.5
+    -0.4999999
     >>> dcor.u_distance_correlation_sqr(b, b)
     1.0
     >>> dcor.u_distance_correlation_sqr(a, b, exponent=0.5)

--- a/dcor/_dcor_internals.py
+++ b/dcor/_dcor_internals.py
@@ -264,6 +264,7 @@ def mean_product(a, b):
     return np.mean(a * b)
 
 
+@njit()
 def u_product(a, b):
     r"""
     Inner product in the Hilbert space of :math:`U`-centered distance matrices.
@@ -335,8 +336,7 @@ def u_product(a, b):
     inf
 
     """
-    n = np.size(a, 0)
-
+    n = a.shape[0]
     return np.sum(a * b) / (n * (n - 3))
 
 

--- a/dcor/_dcor_internals.py
+++ b/dcor/_dcor_internals.py
@@ -7,6 +7,7 @@ distance covariance and correlation.
 import warnings
 
 import numpy as np
+from numba import njit
 
 from . import distances
 from ._utils import _transform_to_2d
@@ -215,6 +216,7 @@ def u_centered(a, *, out=None):
     return out
 
 
+@njit()
 def mean_product(a, b):
     r"""
     Average of the elements for an element-wise product of two matrices.

--- a/dcor/_energy.py
+++ b/dcor/_energy.py
@@ -19,7 +19,7 @@ def _check_valid_energy_exponent(exponent):
 
 
 def _energy_distance_from_distance_matrices(
-        distance_xx, distance_yy, distance_xy, average=None):
+        distance_xx, distance_yy, distance_xy, average=None, stat_type='v'):
     """
     Compute energy distance with precalculated distance matrices.
 
@@ -28,19 +28,29 @@ def _energy_distance_from_distance_matrices(
     average: Callable[[ArrayLike], float]
         A function that will be used to calculate an average of distances.
         This defaults to np.mean.
-
+    stat_type: Literal['u', 'v']
+        If 'u', calculate energy distance using
+        Hoeffding's unbiased U-statistics. Otherwise, use von Mises's biased
+        V-statistics
     """
     if average is None:
         average = np.mean
 
-    return (
-        2 * average(distance_xy) -
-        average(distance_xx) -
-        average(distance_yy)
-    )
+    if stat_type == 'u':
+        return (
+                2 * average(distance_xy) -
+                average(np.triu(distance_xx)) -
+                average(np.triu(distance_yy))
+        )
+    else:
+        return (
+            2 * average(distance_xy) -
+            average(distance_xx) -
+            average(distance_yy)
+        )
 
 
-def energy_distance(x, y, *, average=None, exponent=1):
+def energy_distance(x, y, *, average=None, exponent=1, stat_type='v'):
     """
     Estimator for energy distance.
 
@@ -61,6 +71,10 @@ def energy_distance(x, y, *, average=None, exponent=1):
     average: Callable[[ArrayLike], float]
         A function that will be used to calculate an average of distances.
         This defaults to np.mean.
+    stat_type: Literal['u', 'v']
+        If 'u', calculate energy distance using
+        Hoeffding's unbiased U-statistics. Otherwise, use von Mises's biased
+        V-statistics
 
     Returns
     -------
@@ -111,4 +125,5 @@ def energy_distance(x, y, *, average=None, exponent=1):
         distance_yy=distance_yy,
         distance_xy=distance_xy,
         average=average,
+        stat_type=stat_type
     )

--- a/dcor/_hypothesis.py
+++ b/dcor/_hypothesis.py
@@ -42,7 +42,7 @@ def _permutation_test_with_sym_matrix(matrix, statistic_function,
     HypothesisTest
         Results of the hypothesis test.
     """
-    if random_state:
+    if random_state is not None:
         np.random.seed(random_state)
 
     statistic = statistic_function(matrix)

--- a/dcor/_hypothesis.py
+++ b/dcor/_hypothesis.py
@@ -22,7 +22,7 @@ def _numba_permute(matrix):
 
 @njit()
 def _permutation_test_with_sym_matrix(matrix, statistic_function,
-                                      num_resamples):
+                                      num_resamples, random_state=None):
     """
     Execute a permutation test in a symmetric matrix.
 
@@ -34,12 +34,17 @@ def _permutation_test_with_sym_matrix(matrix, statistic_function,
         Function that computes the desired statistic from the matrix.
     num_resamples: int
         Number of permutations resamples to take in the permutation test.
+    random_state: int
+        Integer used for seeding the random number generator
 
     Returns
     -------
     HypothesisTest
         Results of the hypothesis test.
     """
+    if random_state:
+        np.random.seed(random_state)
+
     statistic = statistic_function(matrix)
 
     bootstrap_statistics = np.ones(num_resamples, np.float_)

--- a/dcor/homogeneity.py
+++ b/dcor/homogeneity.py
@@ -19,17 +19,18 @@ def _energy_test_statistic_coefficient(n, m):
 
 
 def _energy_test_statistic_from_distance_matrices(
-        distance_xx, distance_yy, distance_xy, n, m, average=None):
+        distance_xx, distance_yy, distance_xy, n, m, average=None,
+        stat_type='v'):
     """Test statistic with precomputed distance matrices."""
     energy_distance = _energy._energy_distance_from_distance_matrices(
         distance_xx=distance_xx, distance_yy=distance_yy,
-        distance_xy=distance_xy, average=average
+        distance_xy=distance_xy, average=average, stat_type=stat_type
     )
 
     return _energy_test_statistic_coefficient(n, m) * energy_distance
 
 
-def energy_test_statistic(x, y, *, exponent=1, average=None):
+def energy_test_statistic(x, y, *, exponent=1, average=None, stat_type='v'):
     """
     Homogeneity statistic.
 
@@ -49,6 +50,10 @@ def energy_test_statistic(x, y, *, exponent=1, average=None):
     average: Callable[[ArrayLike], float]
         A function that will be used to calculate an average of distances.
         This defaults to np.mean.
+    stat_type: Literal['u', 'v']
+        If 'u', calculate energy distance using
+        Hoeffding's unbiased U-statistics. Otherwise, use von Mises's biased
+        V-statistics
 
     Returns
     -------
@@ -91,11 +96,12 @@ def energy_test_statistic(x, y, *, exponent=1, average=None):
         y,
         exponent=exponent,
         average=average,
+        stat_type=stat_type
     )
 
 
 def _energy_test_statistic_multivariate_from_distance_matrix(
-        distance, indexes, sizes, average=None):
+        distance, indexes, sizes, average=None, stat_type='v'):
     """Statistic for several random vectors given the distance matrix."""
     energy = 0.0
 
@@ -113,7 +119,9 @@ def _energy_test_statistic_multivariate_from_distance_matrix(
 
             pairwise_energy = _energy_test_statistic_from_distance_matrices(
                 distance_xx=distance_xx, distance_yy=distance_yy,
-                distance_xy=distance_xy, n=n, m=m, average=average)
+                distance_xy=distance_xy, n=n, m=m, average=average,
+                stat_type=stat_type
+                )
 
             energy += pairwise_energy
 
@@ -126,6 +134,7 @@ def energy_test(
     exponent=1,
     random_state=None,
     average=None,
+    stat_type='v'
 ):
     """
     Test of homogeneity based on the energy distance.
@@ -150,6 +159,10 @@ def energy_test(
     average: Callable[[ArrayLike], float]
         A function that will be used to calculate an average of distances.
         This defaults to np.mean.
+    stat_type: Literal['u', 'v']
+        If 'u', calculate energy distance using
+        Hoeffding's unbiased U-statistics. Otherwise, use von Mises's biased
+        V-statistics
 
     Returns
     -------
@@ -225,7 +238,9 @@ def energy_test(
             distance=distance_matrix,
             indexes=sample_indexes,
             sizes=sample_sizes,
-            average=average)
+            average=average,
+            stat_type=stat_type
+            )
 
     return _hypothesis._permutation_test_with_sym_matrix(
         sample_distances,

--- a/dcor/homogeneity.py
+++ b/dcor/homogeneity.py
@@ -193,19 +193,20 @@ def energy_test(
 
     Examples
     --------
-import numpy as np
-import dcor
-a = np.array([[1, 2, 3, 4],
-              [5, 6, 7, 8],
-              [9, 10, 11, 12],
-              [13, 14, 15, 16]])
-b = np.array([[1, 0, 0, 1],
-              [0, 1, 1, 1],
-              [1, 1, 1, 1]])
-c = np.array([[1000, 0, 0, 1000],
-              [0, 1000, 1000, 1000],
-              [1000, 1000, 1000, 1000]])
-    dcor.homogeneity.energy_test(a, a)
+    >>> import numpy as np
+    >>> import numpy as np
+    >>> import dcor
+    >>> a = np.array([[1, 2, 3, 4],
+    ...               [5, 6, 7, 8],
+    ...               [9, 10, 11, 12],
+    ...               [13, 14, 15, 16]])
+    >>> b = np.array([[1, 0, 0, 1],
+    ...               [0, 1, 1, 1],
+    ...               [1, 1, 1, 1]])
+    >>> c = np.array([[1000, 0, 0, 1000],
+    ...               [0, 1000, 1000, 1000],
+    ...               [1000, 1000, 1000, 1000]])
+    >>> dcor.homogeneity.energy_test(a, a)
     HypothesisTest(p_value=1.0, statistic=0.0)
     >>> dcor.homogeneity.energy_test(a, b) # doctest: +ELLIPSIS
     HypothesisTest(p_value=1.0, statistic=35.2766732...)

--- a/dcor/homogeneity.py
+++ b/dcor/homogeneity.py
@@ -10,9 +10,9 @@ import numpy as _np
 
 from numba import njit
 
-from dcor import _energy, _hypothesis
-from dcor import distances as _distances
-from dcor._utils import _transform_to_2d
+from . import _energy, _hypothesis
+from . import distances as _distances
+from ._utils import _transform_to_2d
 
 
 @njit()

--- a/dcor/homogeneity.py
+++ b/dcor/homogeneity.py
@@ -20,7 +20,7 @@ def _energy_test_statistic_coefficient(n, m):
 
 def _energy_test_statistic_from_distance_matrices(
         distance_xx, distance_yy, distance_xy, n, m, average=None,
-        stat_type='v'):
+        stat_type=_energy.EstimationStatistic.VSTATISTIC):
     """Test statistic with precomputed distance matrices."""
     energy_distance = _energy._energy_distance_from_distance_matrices(
         distance_xx=distance_xx, distance_yy=distance_yy,
@@ -50,10 +50,12 @@ def energy_test_statistic(x, y, *, exponent=1, average=None, stat_type='v'):
     average: Callable[[ArrayLike], float]
         A function that will be used to calculate an average of distances.
         This defaults to np.mean.
-    stat_type: Literal['u', 'v']
-        If 'u', calculate energy distance using
+    stat_type: Union[str, EstimationStatistic]
+        If EstimationStatistic.USTATISTIC, calculate energy distance using
         Hoeffding's unbiased U-statistics. Otherwise, use von Mises's biased
-        V-statistics
+        V-statistics.
+        If this is provided as a string, it will first be converted to
+        an EstimationStatistic enum instance.
 
     Returns
     -------
@@ -134,7 +136,7 @@ def energy_test(
     exponent=1,
     random_state=None,
     average=None,
-    stat_type='v'
+    stat_type=_energy.EstimationStatistic.VSTATISTIC
 ):
     """
     Test of homogeneity based on the energy distance.
@@ -159,10 +161,12 @@ def energy_test(
     average: Callable[[ArrayLike], float]
         A function that will be used to calculate an average of distances.
         This defaults to np.mean.
-    stat_type: Literal['u', 'v']
-        If 'u', calculate energy distance using
+    stat_type: Union[str, EstimationStatistic]
+        If EstimationStatistic.USTATISTIC, calculate energy distance using
         Hoeffding's unbiased U-statistics. Otherwise, use von Mises's biased
-        V-statistics
+        V-statistics.
+        If this is provided as a string, it will first be converted to
+        an EstimationStatistic enum instance.
 
     Returns
     -------

--- a/dcor/homogeneity.py
+++ b/dcor/homogeneity.py
@@ -10,9 +10,9 @@ import numpy as _np
 
 from numba import njit
 
-from . import _energy, _hypothesis
-from . import distances as _distances
-from ._utils import _transform_to_2d
+from dcor import _energy, _hypothesis
+from dcor import distances as _distances
+from dcor._utils import _transform_to_2d
 
 
 @njit()
@@ -149,7 +149,8 @@ def energy_test(
     num_resamples=0,
     exponent=1,
     average='mean',
-    stat_type=_energy.EstimationStatistic.V_STATISTIC
+    stat_type=_energy.EstimationStatistic.V_STATISTIC,
+    random_state=None
 ):
     """
     Test of homogeneity based on the energy distance.
@@ -178,6 +179,8 @@ def energy_test(
         V-statistics.
         If this is provided as a string, it will first be converted to
         an EstimationStatistic enum instance.
+    random_state: int
+        Integer used for seeding the random number generator
 
     Returns
     -------
@@ -190,32 +193,29 @@ def energy_test(
 
     Examples
     --------
-    >>> import numpy as np
-    >>> import dcor
-    >>> a = np.array([[1, 2, 3, 4],
-    ...               [5, 6, 7, 8],
-    ...               [9, 10, 11, 12],
-    ...               [13, 14, 15, 16]])
-    >>> b = np.array([[1, 0, 0, 1],
-    ...               [0, 1, 1, 1],
-    ...               [1, 1, 1, 1]])
-    >>> c = np.array([[1000, 0, 0, 1000],
-    ...               [0, 1000, 1000, 1000],
-    ...               [1000, 1000, 1000, 1000]])
-    >>> dcor.homogeneity.energy_test(a, a)
+import numpy as np
+import dcor
+a = np.array([[1, 2, 3, 4],
+              [5, 6, 7, 8],
+              [9, 10, 11, 12],
+              [13, 14, 15, 16]])
+b = np.array([[1, 0, 0, 1],
+              [0, 1, 1, 1],
+              [1, 1, 1, 1]])
+c = np.array([[1000, 0, 0, 1000],
+              [0, 1000, 1000, 1000],
+              [1000, 1000, 1000, 1000]])
+    dcor.homogeneity.energy_test(a, a)
     HypothesisTest(p_value=1.0, statistic=0.0)
     >>> dcor.homogeneity.energy_test(a, b) # doctest: +ELLIPSIS
     HypothesisTest(p_value=1.0, statistic=35.2766732...)
     >>> dcor.homogeneity.energy_test(b, b)
     HypothesisTest(p_value=1.0, statistic=0.0)
-    >>> np.random.seed(0)
-    >>> dcor.homogeneity.energy_test(a, b, num_resamples=5)
+    >>> dcor.homogeneity.energy_test(a, b, num_resamples=5, random_state=0)
     HypothesisTest(p_value=0.1666666..., statistic=35.2766732...)
-    >>> np.random.seed(6)
-    >>> dcor.homogeneity.energy_test(a, b, num_resamples=5)
+    >>> dcor.homogeneity.energy_test(a, b, num_resamples=5, random_state=6)
     HypothesisTest(p_value=0.3333333..., statistic=35.2766732...)
-    >>> np.random.seed(0)
-    >>> dcor.homogeneity.energy_test(a, c, num_resamples=7)
+    >>> dcor.homogeneity.energy_test(a, c, num_resamples=7, random_state=0)
     HypothesisTest(p_value=0.125, statistic=4233.8935035...)
 
     A different exponent for the Euclidean distance in the range
@@ -265,5 +265,6 @@ def energy_test(
     return _hypothesis._permutation_test_with_sym_matrix(
         sample_distances,
         statistic_function=statistic_function,
-        num_resamples=num_resamples
+        num_resamples=num_resamples,
+        random_state=random_state
     )

--- a/dcor/homogeneity.py
+++ b/dcor/homogeneity.py
@@ -20,7 +20,7 @@ def _energy_test_statistic_coefficient(n, m):
 
 def _energy_test_statistic_from_distance_matrices(
         distance_xx, distance_yy, distance_xy, n, m, average=None,
-        stat_type=_energy.EstimationStatistic.VSTATISTIC):
+        stat_type=_energy.EstimationStatistic.V_STATISTIC):
     """Test statistic with precomputed distance matrices."""
     energy_distance = _energy._energy_distance_from_distance_matrices(
         distance_xx=distance_xx, distance_yy=distance_yy,
@@ -51,7 +51,7 @@ def energy_test_statistic(x, y, *, exponent=1, average=None, stat_type='v'):
         A function that will be used to calculate an average of distances.
         This defaults to np.mean.
     stat_type: Union[str, EstimationStatistic]
-        If EstimationStatistic.USTATISTIC, calculate energy distance using
+        If EstimationStatistic.U_STATISTIC, calculate energy distance using
         Hoeffding's unbiased U-statistics. Otherwise, use von Mises's biased
         V-statistics.
         If this is provided as a string, it will first be converted to
@@ -136,7 +136,7 @@ def energy_test(
     exponent=1,
     random_state=None,
     average=None,
-    stat_type=_energy.EstimationStatistic.VSTATISTIC
+    stat_type=_energy.EstimationStatistic.V_STATISTIC
 ):
     """
     Test of homogeneity based on the energy distance.
@@ -162,7 +162,7 @@ def energy_test(
         A function that will be used to calculate an average of distances.
         This defaults to np.mean.
     stat_type: Union[str, EstimationStatistic]
-        If EstimationStatistic.USTATISTIC, calculate energy distance using
+        If EstimationStatistic.U_STATISTIC, calculate energy distance using
         Hoeffding's unbiased U-statistics. Otherwise, use von Mises's biased
         V-statistics.
         If this is provided as a string, it will first be converted to

--- a/dcor/independence.py
+++ b/dcor/independence.py
@@ -161,20 +161,20 @@ def partial_distance_covariance_test(
 
     Examples
     --------
-import numpy as np
-import dcor
-a = np.array([[1, 2, 3, 4],
-              [5, 6, 7, 8],
-              [9, 10, 11, 12],
-              [13, 14, 15, 16]])
-b = np.array([[1, 0, 0, 1],
-              [0, 1, 1, 1],
-              [1, 1, 1, 1],
-              [1, 1, 0, 1]])
-c = np.array([[1000, 0, 0, 1000],
-              [0, 1000, 1000, 1000],
-              [1000, 1000, 1000, 1000],
-              [1000, 1000, 0, 1000]])
+    >>> import numpy as np
+    >>> import dcor
+    >>> a = np.array([[1, 2, 3, 4],
+    ...               [5, 6, 7, 8],
+    ...               [9, 10, 11, 12],
+    ...               [13, 14, 15, 16]])
+    >>> b = np.array([[1, 0, 0, 1],
+    ...               [0, 1, 1, 1],
+    ...               [1, 1, 1, 1],
+    ...               [1, 1, 0, 1]])
+    >>> c = np.array([[1000, 0, 0, 1000],
+    ...               [0, 1000, 1000, 1000],
+    ...               [1000, 1000, 1000, 1000],
+    ...               [1000, 1000, 0, 1000]])
     >>> dcor.independence.partial_distance_covariance_test(a, a, b)
     ...                                       # doctest: +ELLIPSIS
     HypothesisTest(p_value=1.0, statistic=142.6664416...)

--- a/dcor/independence.py
+++ b/dcor/independence.py
@@ -79,11 +79,11 @@ def distance_covariance_test(
     ... num_resamples=5, random_state=0)
     HypothesisTest(p_value=0.5, statistic=11.7532305...)
     >>> dcor.independence.distance_covariance_test(a, b,
-    ... num_resamples=5, random_state=13)
+    ... num_resamples=5, random_state=8)
     HypothesisTest(p_value=0.3333333..., statistic=11.7532305...)
     >>> dcor.independence.distance_covariance_test(a, a,
-    ... num_resamples=7, random_state=0)
-    HypothesisTest(p_value=0.125, statistic=208.0)
+    ... num_resamples=7, random_state=2)
+    HypothesisTest(p_value=1.6666666..., statistic=208.0)
 
     """
     x = _transform_to_2d(x)
@@ -195,8 +195,6 @@ def partial_distance_covariance_test(
     HypothesisTest(p_value=1.0, statistic=-7.5701764...e-12)
 
     """
-    random_state = _random_state_init(random_state)
-
     # Compute U-centered matrices
     u_x = _dcor_internals._u_distance_matrix(x, exponent=exponent)
     u_y = _dcor_internals._u_distance_matrix(y, exponent=exponent)

--- a/dcor/independence.py
+++ b/dcor/independence.py
@@ -161,20 +161,20 @@ def partial_distance_covariance_test(
 
     Examples
     --------
-    >>> import numpy as np
-    >>> import dcor
-    >>> a = np.array([[1, 2, 3, 4],
-    ...               [5, 6, 7, 8],
-    ...               [9, 10, 11, 12],
-    ...               [13, 14, 15, 16]])
-    >>> b = np.array([[1, 0, 0, 1],
-    ...               [0, 1, 1, 1],
-    ...               [1, 1, 1, 1],
-    ...               [1, 1, 0, 1]])
-    >>> c = np.array([[1000, 0, 0, 1000],
-    ...               [0, 1000, 1000, 1000],
-    ...               [1000, 1000, 1000, 1000],
-    ...               [1000, 1000, 0, 1000]])
+import numpy as np
+import dcor
+a = np.array([[1, 2, 3, 4],
+              [5, 6, 7, 8],
+              [9, 10, 11, 12],
+              [13, 14, 15, 16]])
+b = np.array([[1, 0, 0, 1],
+              [0, 1, 1, 1],
+              [1, 1, 1, 1],
+              [1, 1, 0, 1]])
+c = np.array([[1000, 0, 0, 1000],
+              [0, 1000, 1000, 1000],
+              [1000, 1000, 1000, 1000],
+              [1000, 1000, 0, 1000]])
     >>> dcor.independence.partial_distance_covariance_test(a, a, b)
     ...                                       # doctest: +ELLIPSIS
     HypothesisTest(p_value=1.0, statistic=142.6664416...)
@@ -207,6 +207,7 @@ def partial_distance_covariance_test(
     p_yz = proj(u_y)
 
     # Use the pdcor statistic
+    @njit()
     def statistic_function(distance_matrix):
         return u_x.shape[0] * _dcor_internals.u_product(
             distance_matrix, p_yz)

--- a/dcor/independence.py
+++ b/dcor/independence.py
@@ -6,6 +6,7 @@ the samples generated from two random vectors are independent.
 """
 import numpy as np
 import scipy.stats
+from numba import njit
 
 from . import _dcor_internals, _hypothesis
 from ._dcor import u_distance_correlation_sqr
@@ -17,7 +18,8 @@ def distance_covariance_test(
     y,
     *,
     num_resamples=0,
-    exponent=1
+    exponent=1,
+    random_state=None
 ):
     """
     Test of distance covariance independence.
@@ -42,6 +44,8 @@ def distance_covariance_test(
         motion.
     num_resamples: int
         Number of permutations resamples to take in the permutation test.
+    random_state: int
+        Random state to generate the permutations.
 
     Returns
     -------
@@ -98,6 +102,7 @@ def distance_covariance_test(
         exponent=exponent)
 
     # Use the dcov statistic
+    @njit()
     def statistic_function(distance_matrix):
         return u_x.shape[0] * _dcor_internals.mean_product(
             distance_matrix, u_y)
@@ -105,7 +110,9 @@ def distance_covariance_test(
     return _hypothesis._permutation_test_with_sym_matrix(
         u_x,
         statistic_function=statistic_function,
-        num_resamples=num_resamples)
+        num_resamples=num_resamples,
+        random_state=random_state
+    )
 
 
 def partial_distance_covariance_test(

--- a/dcor/independence.py
+++ b/dcor/independence.py
@@ -17,8 +17,7 @@ def distance_covariance_test(
     y,
     *,
     num_resamples=0,
-    exponent=1,
-    random_state=None,
+    exponent=1
 ):
     """
     Test of distance covariance independence.
@@ -43,8 +42,6 @@ def distance_covariance_test(
         motion.
     num_resamples: int
         Number of permutations resamples to take in the permutation test.
-    random_state: {None, int, array_like, numpy.random.RandomState}
-        Random state to generate the permutations.
 
     Returns
     -------
@@ -90,8 +87,6 @@ def distance_covariance_test(
 
     _dcor_internals._check_same_n_elements(x, y)
 
-    random_state = _random_state_init(random_state)
-
     # Compute U-centered matrices
     u_x = _dcor_internals._distance_matrix_generic(
         x,
@@ -110,8 +105,7 @@ def distance_covariance_test(
     return _hypothesis._permutation_test_with_sym_matrix(
         u_x,
         statistic_function=statistic_function,
-        num_resamples=num_resamples,
-        random_state=random_state)
+        num_resamples=num_resamples)
 
 
 def partial_distance_covariance_test(

--- a/dcor/tests/speed_permutation.py
+++ b/dcor/tests/speed_permutation.py
@@ -1,0 +1,14 @@
+import numpy as np
+import dcor
+
+num_samples = 100
+np.random.seed(0)
+a = np.random.normal(loc=1, size=(num_samples, 1))
+b = np.random.normal(loc=2, size=(num_samples, 1))
+result = dcor.homogeneity.energy_test(
+    a,
+    b,
+    num_resamples=5000
+)
+print(result.p_value)
+

--- a/dcor/tests/speed_permutation.py
+++ b/dcor/tests/speed_permutation.py
@@ -2,15 +2,20 @@ import numpy as np
 import dcor
 import sys
 
-resamples = int(sys.argv[1])
-num_samples = 100
-np.random.seed(0)
-a = np.random.normal(loc=1, size=(num_samples, 1))
-b = np.random.normal(loc=2, size=(num_samples, 1))
-result = dcor.homogeneity.energy_test(
-    a,
-    b,
-    num_resamples=resamples
-)
-print(result.p_value)
 
+def main():
+    resamples = int(sys.argv[1])
+    num_samples = 100
+    np.random.seed(0)
+    a = np.random.normal(loc=1, size=(num_samples, 1))
+    b = np.random.normal(loc=2, size=(num_samples, 1))
+    result = dcor.homogeneity.energy_test(
+        a,
+        b,
+        num_resamples=resamples
+    )
+    print(result.p_value)
+
+
+if __name__ == '__main__':
+    main()

--- a/dcor/tests/speed_permutation.py
+++ b/dcor/tests/speed_permutation.py
@@ -1,6 +1,8 @@
 import numpy as np
 import dcor
+import sys
 
+resamples = int(sys.argv[1])
 num_samples = 100
 np.random.seed(0)
 a = np.random.normal(loc=1, size=(num_samples, 1))
@@ -8,7 +10,7 @@ b = np.random.normal(loc=2, size=(num_samples, 1))
 result = dcor.homogeneity.energy_test(
     a,
     b,
-    num_resamples=5000
+    num_resamples=resamples
 )
 print(result.p_value)
 

--- a/dcor/tests/test_energy.py
+++ b/dcor/tests/test_energy.py
@@ -1,0 +1,39 @@
+import numpy as np
+from dcor._energy import _energy_distance_from_distance_matrices
+import unittest
+
+
+class TestEnergyTest(unittest.TestCase):
+    """Tests for energy statistics"""
+
+    def test_u_v_statistics(self):
+        """
+        V-statistics count the 0 terms on the diagonal, so the impact of the
+        within-sample distance will be smaller, making the overall distance
+        larger
+        """
+        distance_within = np.array([
+            [0, 1, 1],
+            [1, 0, 1],
+            [1, 1, 0],
+        ])
+        distance_between = np.array([
+            [1, 1, 1],
+            [1, 1, 1],
+            [1, 1, 2],
+        ])
+
+        u_dist = _energy_distance_from_distance_matrices(
+            distance_xx=distance_within,
+            distance_yy=distance_within,
+            distance_xy=distance_between,
+            stat_type='u'
+        )
+        v_dist = _energy_distance_from_distance_matrices(
+            distance_xx=distance_within,
+            distance_yy=distance_within,
+            distance_xy=distance_between,
+            stat_type='v'
+        )
+
+        assert u_dist > v_dist

--- a/dcor/tests/test_energy.py
+++ b/dcor/tests/test_energy.py
@@ -1,5 +1,6 @@
 import numpy as np
-from dcor._energy import _energy_distance_from_distance_matrices
+from dcor._energy import _energy_distance_from_distance_matrices,\
+    EstimationStatistic
 import unittest
 
 
@@ -8,9 +9,11 @@ class TestEnergyTest(unittest.TestCase):
 
     def test_u_v_statistics(self):
         """
-        V-statistics count the 0 terms on the diagonal, so the impact of the
-        within-sample distance will be smaller, making the overall distance
-        larger
+        Test that we are correctly applying the provided type of estimation
+        statistics
+
+        Also tests that we can choose a statistic type using either a string
+        or an enum instance
         """
         distance_within = np.array([
             [0, 1, 1],
@@ -20,14 +23,14 @@ class TestEnergyTest(unittest.TestCase):
         distance_between = np.array([
             [1, 1, 1],
             [1, 1, 1],
-            [1, 1, 2],
+            [1, 1, 1],
         ])
 
         u_dist = _energy_distance_from_distance_matrices(
             distance_xx=distance_within,
             distance_yy=distance_within,
             distance_xy=distance_between,
-            stat_type='u'
+            stat_type=EstimationStatistic.USTATISTIC
         )
         v_dist = _energy_distance_from_distance_matrices(
             distance_xx=distance_within,
@@ -36,4 +39,11 @@ class TestEnergyTest(unittest.TestCase):
             stat_type='v'
         )
 
-        assert u_dist > v_dist
+        # V-statistics count the 0 terms on the diagonal, so the impact of the
+        # within-sample distance will be smaller, making the overall distance
+        # larger.
+        self.assertGreater(v_dist, u_dist)
+
+        # Also test for exact values
+        self.assertEqual(u_dist, 0)
+        self.assertAlmostEqual(v_dist, 2/3)

--- a/dcor/tests/test_energy.py
+++ b/dcor/tests/test_energy.py
@@ -1,6 +1,6 @@
 import numpy as np
-from dcor._energy import _energy_distance_from_distance_matrices,\
-    EstimationStatistic
+from dcor._energy import _energy_distance_from_distance_matrices
+from dcor import EstimationStatistic
 import unittest
 
 
@@ -30,7 +30,7 @@ class TestEnergyTest(unittest.TestCase):
             distance_xx=distance_within,
             distance_yy=distance_within,
             distance_xy=distance_between,
-            stat_type=EstimationStatistic.USTATISTIC
+            stat_type=EstimationStatistic.U_STATISTIC
         )
         v_dist = _energy_distance_from_distance_matrices(
             distance_xx=distance_within,

--- a/dcor/tests/test_energy.py
+++ b/dcor/tests/test_energy.py
@@ -36,7 +36,7 @@ class TestEnergyTest(unittest.TestCase):
             distance_xx=distance_within,
             distance_yy=distance_within,
             distance_xy=distance_between,
-            stat_type='v'
+            stat_type=EstimationStatistic.V_STATISTIC
         )
 
         # V-statistics count the 0 terms on the diagonal, so the impact of the

--- a/dcor/tests/test_homogeneity.py
+++ b/dcor/tests/test_homogeneity.py
@@ -1,11 +1,11 @@
 """Tests of the homogeneity module"""
 
-import time
-import unittest
+import os
 import subprocess
 import sys
+import time
+import unittest
 from pathlib import Path
-import os
 
 import numpy as np
 
@@ -208,7 +208,7 @@ class TestEnergyTest(unittest.TestCase):
             args=[
                 sys.executable,
                 str(here / 'speed_permutation.py'),
-                '5000'
+                '300'
             ],
             capture_output=True,
             check=True,
@@ -231,7 +231,8 @@ class TestEnergyTest(unittest.TestCase):
             msg='Numba JIT produced a different result to plain Python'
         )
         self.assertLess(
-            10 * (mid - start),
+            mid - start,
             end - mid,
-            msg='Numba JIT is not at least 10 times faster than plain Python'
+            msg='Numba JIT is not faster than plain Python for 300'
+                'permutations'
         )

--- a/dcor/tests/test_homogeneity.py
+++ b/dcor/tests/test_homogeneity.py
@@ -1,9 +1,15 @@
 """Tests of the homogeneity module"""
 
+import time
 import unittest
+import subprocess
+import sys
+from pathlib import Path
+import os
+
+import numpy as np
 
 import dcor
-import numpy as np
 
 
 class TestEnergyTest(unittest.TestCase):
@@ -22,20 +28,27 @@ class TestEnergyTest(unittest.TestCase):
         mean = np.zeros(vector_size)
         cov = np.eye(vector_size)
 
-        random_state = np.random.RandomState(0)
+        np.random.seed(0)
 
-        a = random_state.multivariate_normal(mean=mean,
-                                             cov=cov,
-                                             size=num_samples)
-        b = random_state.multivariate_normal(mean=mean,
-                                             cov=cov,
-                                             size=num_samples)
+        a = np.random.multivariate_normal(
+            mean=mean,
+            cov=cov,
+            size=num_samples
+        )
+        b = np.random.multivariate_normal(
+            mean=mean,
+            cov=cov,
+            size=num_samples
+        )
 
         significance = 0.01
         num_resamples = int(3 / significance + 1)
 
         result = dcor.homogeneity.energy_test(
-            a, b, num_resamples=num_resamples, random_state=random_state)
+            a,
+            b,
+            num_resamples=num_resamples
+        )
 
         self.assertGreater(result.p_value, significance)
 
@@ -53,18 +66,18 @@ class TestEnergyTest(unittest.TestCase):
         mean_1 = np.ones(vector_size)
         cov = np.eye(vector_size)
 
-        random_state = np.random.RandomState(0)
+        np.random.seed(0)
 
-        a = random_state.multivariate_normal(mean=mean_0, cov=cov,
-                                             size=num_samples)
-        b = random_state.multivariate_normal(mean=mean_1, cov=cov,
-                                             size=num_samples)
+        a = np.random.multivariate_normal(mean=mean_0, cov=cov,
+                                          size=num_samples)
+        b = np.random.multivariate_normal(mean=mean_1, cov=cov,
+                                          size=num_samples)
 
         significance = 0.01
         num_resamples = int(3 / significance + 1)
 
         result = dcor.homogeneity.energy_test(
-            a, b, num_resamples=num_resamples, random_state=random_state)
+            a, b, num_resamples=num_resamples)
 
         self.assertLess(result.p_value, significance)
 
@@ -82,18 +95,18 @@ class TestEnergyTest(unittest.TestCase):
         cov_0 = np.eye(vector_size)
         cov_1 = 3 * np.eye(vector_size)
 
-        random_state = np.random.RandomState(0)
+        np.random.seed(0)
 
-        a = random_state.multivariate_normal(mean=mean, cov=cov_0,
-                                             size=num_samples)
-        b = random_state.multivariate_normal(mean=mean, cov=cov_1,
-                                             size=num_samples)
+        a = np.random.multivariate_normal(mean=mean, cov=cov_0,
+                                          size=num_samples)
+        b = np.random.multivariate_normal(mean=mean, cov=cov_1,
+                                          size=num_samples)
 
         significance = 0.01
         num_resamples = int(3 / significance + 1)
 
         result = dcor.homogeneity.energy_test(
-            a, b, num_resamples=num_resamples, random_state=random_state)
+            a, b, num_resamples=num_resamples)
 
         self.assertLess(result.p_value, significance)
 
@@ -107,16 +120,19 @@ class TestEnergyTest(unittest.TestCase):
         """
         num_samples = 100
 
-        random_state = np.random.RandomState(0)
+        np.random.seed(0)
 
-        a = random_state.standard_normal(size=(num_samples, 1))
-        b = random_state.standard_t(df=1, size=(num_samples, 1))
+        a = np.random.standard_normal(size=(num_samples, 1))
+        b = np.random.standard_t(df=1, size=(num_samples, 1))
 
         significance = 0.01
         num_resamples = int(3 / significance + 1)
 
         result = dcor.homogeneity.energy_test(
-            a, b, num_resamples=num_resamples, random_state=random_state)
+            a,
+            b,
+            num_resamples=num_resamples
+        )
 
         self.assertLess(result.p_value, significance)
 
@@ -127,10 +143,10 @@ class TestEnergyTest(unittest.TestCase):
         """
         num_samples = 100
 
-        random_state = np.random.RandomState(0)
+        np.random.seed(0)
 
-        a = random_state.normal(loc=0, size=(num_samples, 1))
-        b = random_state.normal(loc=1, size=(num_samples, 1))
+        a = np.random.normal(loc=0, size=(num_samples, 1))
+        b = np.random.normal(loc=1, size=(num_samples, 1))
 
         significance = 0.01
         num_resamples = int(3 / significance + 1)
@@ -139,16 +155,14 @@ class TestEnergyTest(unittest.TestCase):
             a,
             b,
             num_resamples=num_resamples,
-            random_state=random_state,
-            average=np.median
+            average='median'
         )
 
         mean_result = dcor.homogeneity.energy_test(
             a,
             b,
             num_resamples=num_resamples,
-            random_state=random_state,
-            average=np.mean
+            average='mean'
         )
 
         # Check that we are actually using a different average
@@ -166,10 +180,10 @@ class TestEnergyTest(unittest.TestCase):
         """
         num_samples = 100
 
-        random_state = np.random.RandomState(0)
+        np.random.seed(0)
 
-        a = random_state.normal(loc=1, size=(num_samples, 1))
-        b = random_state.exponential(scale=1, size=(num_samples, 1))
+        a = np.random.normal(loc=1, size=(num_samples, 1))
+        b = np.random.exponential(scale=1, size=(num_samples, 1))
 
         significance = 0.01
         num_resamples = int(3 / significance + 1)
@@ -177,9 +191,46 @@ class TestEnergyTest(unittest.TestCase):
         result = dcor.homogeneity.energy_test(
             a,
             b,
-            average=np.median,
-            num_resamples=num_resamples,
-            random_state=random_state
+            average='median',
+            num_resamples=num_resamples
         )
 
         self.assertLess(result.p_value, significance)
+
+    def test_speed_permutation(self):
+        """
+        Run the permutation with and without numba, and check that numba is
+        indeed providing a speedup
+        """
+        start = time.time()
+        here = Path(__file__).parent
+        kwargs = dict(
+            args=[
+                sys.executable,
+                str(here / 'speed_permutation.py')
+            ],
+            capture_output=True,
+            check=True,
+            cwd=here
+        )
+        numba_result = subprocess.run(**kwargs)
+        mid = time.time()
+        no_numba_result = subprocess.run(
+            **kwargs,
+            env={
+                'NUMBA_DISABLE_JIT': '1',
+                **os.environ
+            }
+        )
+        end = time.time()
+
+        self.assertEqual(
+            numba_result.stdout,
+            no_numba_result.stdout,
+            msg='Numba JIT produced a different result to plain Python'
+        )
+        self.assertLess(
+            10 * (mid - start),
+            end - mid,
+            msg='Numba JIT is not at least 10 times faster than plain Python'
+        )

--- a/dcor/tests/test_homogeneity.py
+++ b/dcor/tests/test_homogeneity.py
@@ -207,7 +207,8 @@ class TestEnergyTest(unittest.TestCase):
         kwargs = dict(
             args=[
                 sys.executable,
-                str(here / 'speed_permutation.py')
+                str(here / 'speed_permutation.py'),
+                '5000'
             ],
             capture_output=True,
             check=True,

--- a/dcor/tests/test_independence.py
+++ b/dcor/tests/test_independence.py
@@ -2,8 +2,9 @@
 
 import unittest
 
-import dcor
 import numpy as np
+
+import dcor
 
 
 class TestDcovTest(unittest.TestCase):
@@ -22,20 +23,20 @@ class TestDcovTest(unittest.TestCase):
         mean = np.zeros(vector_size)
         cov = np.eye(vector_size)
 
-        random_state = np.random.RandomState(0)
+        np.random.seed(0)
 
-        a = random_state.multivariate_normal(mean=mean,
-                                             cov=cov,
-                                             size=num_samples)
-        b = random_state.multivariate_normal(mean=mean,
-                                             cov=cov,
-                                             size=num_samples)
+        a = np.random.multivariate_normal(mean=mean,
+                                          cov=cov,
+                                          size=num_samples)
+        b = np.random.multivariate_normal(mean=mean,
+                                          cov=cov,
+                                          size=num_samples)
 
         significance = 0.01
         num_resamples = int(3 / significance + 1)
 
         result = dcor.independence.distance_covariance_test(
-            a, b, num_resamples=num_resamples, random_state=random_state)
+            a, b, num_resamples=num_resamples)
 
         self.assertGreater(result.p_value, significance)
 
@@ -52,18 +53,18 @@ class TestDcovTest(unittest.TestCase):
         mean = np.zeros(vector_size)
         cov = np.eye(vector_size)
 
-        random_state = np.random.RandomState(0)
+        np.random.seed(0)
 
-        a = random_state.multivariate_normal(mean=mean,
-                                             cov=cov,
-                                             size=num_samples)
+        a = np.random.multivariate_normal(mean=mean,
+                                          cov=cov,
+                                          size=num_samples)
         b = a
 
         significance = 0.01
         num_resamples = int(3 / significance + 1)
 
         result = dcor.independence.distance_covariance_test(
-            a, b, num_resamples=num_resamples, random_state=random_state)
+            a, b, num_resamples=num_resamples)
 
         self.assertLess(result.p_value, significance)
 
@@ -81,18 +82,18 @@ class TestDcovTest(unittest.TestCase):
         mean = np.zeros(vector_size)
         cov = np.eye(vector_size)
 
-        random_state = np.random.RandomState(0)
+        np.random.seed(0)
 
-        a = random_state.multivariate_normal(mean=mean,
-                                             cov=cov,
-                                             size=num_samples)
+        a = np.random.multivariate_normal(mean=mean,
+                                          cov=cov,
+                                          size=num_samples)
         b = np.sin(a) + 3 * a ** 2
 
         significance = 0.01
         num_resamples = int(3 / significance + 1)
 
         result = dcor.independence.distance_covariance_test(
-            a, b, num_resamples=num_resamples, random_state=random_state)
+            a, b, num_resamples=num_resamples)
 
         self.assertLess(result.p_value, significance)
 
@@ -109,19 +110,22 @@ class TestDcovTest(unittest.TestCase):
         mean = np.zeros(vector_size)
         cov = np.eye(vector_size)
 
-        random_state = np.random.RandomState(0)
+        np.random.seed(0)
 
-        a = random_state.multivariate_normal(mean=mean,
-                                             cov=cov,
-                                             size=num_samples)
-        b = random_state.multivariate_normal(mean=mean,
-                                             cov=cov,
-                                             size=num_samples) + np.sin(a)
+        a = np.random.multivariate_normal(mean=mean,
+                                          cov=cov,
+                                          size=num_samples)
+        b = np.random.multivariate_normal(mean=mean,
+                                          cov=cov,
+                                          size=num_samples) + np.sin(a)
 
         significance = 0.01
         num_resamples = int(3 / significance + 1)
 
         result = dcor.independence.distance_covariance_test(
-            a, b, num_resamples=num_resamples, random_state=random_state)
+            a,
+            b,
+            num_resamples=num_resamples
+        )
 
         self.assertLess(result.p_value, significance)


### PR DESCRIPTION
Note: this builds on #27, and changes from that branch will appear here until that is merged.

This re-implements most of the energy distance functions and permutation tests using numba. This provides significant performance improvements. I have some benchmarks below, which compare numba to pure Python (note: this isn't comparing numba to original code that used numpy tricks, it's comparing my changes with and without the JIT). The results suggest that numba improves performance for any number of permutations above 250. I expect this will also be true of multiple different permutation tests in the same program.

![image](https://user-images.githubusercontent.com/5019367/109460739-2e562980-7ab5-11eb-9d97-dda171af5531.png)

And with slightly higher limits:
![image](https://user-images.githubusercontent.com/5019367/109460294-745ebd80-7ab4-11eb-9de6-db15691d8b08.png)

However, the costs are:
* Some ugly numba workarounds, like re-implementing the permutation function using nested loops
* We lose the ability to pass in arbitrary average functions, the `average` parameter is now a string which is either `mean` or `median`
* We lose the use of the `RandomState` object, and have to rely on only `np.random.seed()`
* Startup costs associated with JIT compiler. Thus, for less than 250 permutations, the JIT compilation slows down the task.