### PR TITLE
Parallelize the permutation test with joblib.

### DIFF
--- a/dcor/homogeneity.py
+++ b/dcor/homogeneity.py
@@ -145,7 +145,8 @@ def energy_test(
     exponent=1,
     random_state=None,
     average=None,
-    estimation_stat=_energy.EstimationStatistic.V_STATISTIC
+    estimation_stat=_energy.EstimationStatistic.V_STATISTIC,
+    n_jobs=1,
 ):
     """
     Test of homogeneity based on the energy distance.
@@ -259,4 +260,5 @@ def energy_test(
         sample_distances,
         statistic_function=statistic_function,
         num_resamples=num_resamples,
-        random_state=random_state)
+        random_state=random_state,
+        n_jobs=n_jobs)

--- a/dcor/independence.py
+++ b/dcor/independence.py
@@ -19,6 +19,7 @@ def distance_covariance_test(
     num_resamples=0,
     exponent=1,
     random_state=None,
+    n_jobs=1,
 ):
     """
     Test of distance covariance independence.
@@ -111,7 +112,8 @@ def distance_covariance_test(
         u_x,
         statistic_function=statistic_function,
         num_resamples=num_resamples,
-        random_state=random_state)
+        random_state=random_state,
+        n_jobs=n_jobs)
 
 
 def partial_distance_covariance_test(
@@ -122,6 +124,7 @@ def partial_distance_covariance_test(
     num_resamples=0,
     exponent=1,
     random_state=None,
+    n_jobs=1,
 ):
     """
     Test of partial distance covariance independence.
@@ -216,7 +219,8 @@ def partial_distance_covariance_test(
         p_xz,
         statistic_function=statistic_function,
         num_resamples=num_resamples,
-        random_state=random_state)
+        random_state=random_state,
+        n_jobs=n_jobs)
 
 
 def distance_correlation_t_statistic(x, y):


### PR DESCRIPTION
Hey!

I parallelized the permutation test quite simply with joblib. It should behave similarly as it did before because by default n_jobs=1, so should only be 1 thread/process by default. But for those who want to parallelize can add the n_jobs parameter when they call the permutation functions. 

Hopefully this is OK. It works for me.

Cheers,
Ameer