### PR TITLE
Use array_api_compat

### DIFF
--- a/dcor/_dcor.py
+++ b/dcor/_dcor.py
@@ -34,7 +34,13 @@ from dcor._dcor_internals import _af_inv_scaled
 from ._dcor_internals import _dcov_from_terms, _dcov_terms_naive
 from ._fast_dcov_avl import _distance_covariance_sqr_terms_avl
 from ._fast_dcov_mergesort import _distance_covariance_sqr_terms_mergesort
-from ._utils import ArrayType, CompileMode, _sqrt, get_namespace
+from ._utils import (
+    ArrayType,
+    CompileMode,
+    _sqrt,
+    array_namespace,
+    numpy_namespace,
+)
 
 Array = TypeVar("Array", bound=ArrayType)
 
@@ -183,11 +189,11 @@ def _dcov_terms_auto(
     Array | None,
     Array | None,
 ]:
-    xp = get_namespace(x, y)
+    xp = array_namespace(x, y)
 
     dcov_terms = _dcov_terms_naive
 
-    if xp == np and _can_use_fast_algorithm(x, y, exponent):
+    if xp == numpy_namespace and _can_use_fast_algorithm(x, y, exponent):
         dcov_terms = _distance_covariance_sqr_terms_avl
 
     return dcov_terms(
@@ -287,10 +293,10 @@ class _DcovAlgorithmInternals():
             bias_corrected=bias_corrected,
         )
 
-        xp = get_namespace(x, y)
+        xp = array_namespace(x, y)
 
         denominator_sqr = xp.abs(variance_x_sqr * variance_y_sqr)
-        denominator = _sqrt(denominator_sqr)
+        denominator = _sqrt(xp.asarray(denominator_sqr))
 
         # Comparisons using a tolerance can change results if the
         # covariance has a similar order of magnitude
@@ -347,7 +353,7 @@ def _distance_stats_sqr_generic(
     if exponent != 1:
         raise ValueError(f"Exponent should be 1 but is {exponent} instead.")
 
-    xp = get_namespace(x, y)
+    xp = array_namespace(x, y)
 
     covariance_xy_sqr = dcov_function(x, y, compile_mode=compile_mode)
     variance_x_sqr = dcov_function(x, x, compile_mode=compile_mode)
@@ -1095,7 +1101,7 @@ def distance_correlation_af_inv_sqr(
         compile_mode=compile_mode,
     )
 
-    xp = get_namespace(x, y)
+    xp = array_namespace(x, y)
 
     return (
         xp.zeros_like(correlation)

--- a/dcor/_dcor_internals.py
+++ b/dcor/_dcor_internals.py
@@ -10,7 +10,7 @@ import warnings
 from typing import Callable, Literal, Protocol, Tuple, TypeVar, overload
 
 from . import distances
-from ._utils import ArrayType, CompileMode, _transform_to_2d, get_namespace
+from ._utils import ArrayType, CompileMode, _transform_to_2d, array_namespace
 
 Array = TypeVar("Array", bound=ArrayType)
 
@@ -42,7 +42,7 @@ def _check_valid_dcov_exponent(exponent: float) -> None:
 
 
 def _check_same_n_elements(x: Array, y: Array) -> None:
-    xp = get_namespace(x, y)
+    xp = array_namespace(x, y)
 
     x = xp.asarray(x)
     y = xp.asarray(y)
@@ -79,7 +79,7 @@ def _symmetric_matrix_sums(a: Array) -> Tuple[Array, Array]:
     # Thus, we assume data is C-contiguous and then the faster array is 1.
     fast_axis = 1
 
-    xp = get_namespace(a)
+    xp = array_namespace(a)
 
     axis_sum = xp.sum(a, axis=fast_axis)
     total_sum = xp.sum(axis_sum)
@@ -149,7 +149,7 @@ def _dcov_terms_naive(
             f"Compile mode {compile_mode} not implemented.",
         )
 
-    xp = get_namespace(x, y)
+    xp = array_namespace(x, y)
     a, b = _compute_distances(
         x,
         y,
@@ -342,7 +342,7 @@ def u_centered(a: Array, *, out: Array | None = None) -> Array:
     out += total_u_mean
 
     # The diagonal is zero
-    xp = get_namespace(a)
+    xp = array_namespace(a)
     out[xp.eye(dim, dtype=xp.bool)] = 0
 
     return out
@@ -385,7 +385,7 @@ def mean_product(a: Array, b: Array) -> Array:
         2.5
 
     """
-    xp = get_namespace(a, b)
+    xp = array_namespace(a, b)
     return xp.mean(a * b)
 
 
@@ -455,7 +455,7 @@ def u_product(a: Array, b: Array) -> Array:
     """
     n = a.shape[0]
 
-    xp = get_namespace(a, b)
+    xp = array_namespace(a, b)
 
     return xp.sum(a * b) / (n * (n - 3))
 
@@ -552,7 +552,7 @@ def u_projection(a: Array) -> Callable[[Array], Array]:
         u_projection
     """
 
-    xp = get_namespace(a)
+    xp = array_namespace(a)
 
     if denominator == 0:
 
@@ -701,7 +701,7 @@ def _u_distance_matrix(x: Array, *, exponent: float = 1) -> Array:
 
 
 def _mat_sqrt_inv(matrix: Array) -> Array:
-    xp = get_namespace(matrix)
+    xp = array_namespace(matrix)
 
     eigenvalues, eigenvectors = xp.linalg.eigh(matrix)
 
@@ -716,7 +716,7 @@ def _cov(x: Array) -> Array:
     """Equivalent to np.cov(x, rowvar=False)."""
     x, = _transform_to_2d(x)
 
-    xp = get_namespace(x)
+    xp = array_namespace(x)
 
     mean = xp.mean(x, axis=0, keepdims=True)
     x_centered = x - mean

--- a/dcor/_energy.py
+++ b/dcor/_energy.py
@@ -7,7 +7,7 @@ from enum import Enum, auto
 from typing import Callable, Literal, TypeVar, Union
 
 from . import distances
-from ._utils import ArrayType, _transform_to_2d, get_namespace
+from ._utils import ArrayType, _transform_to_2d, array_namespace
 
 Array = TypeVar("Array", bound=ArrayType)
 
@@ -77,7 +77,7 @@ def _check_valid_energy_exponent(exponent: float) -> None:
 
 def _get_flat_upper_matrix(x: Array, k: int) -> Array:
     """Get flat upper matrix from diagonal k."""
-    xp = get_namespace(x)
+    xp = array_namespace(x)
     x_mask = xp.triu(xp.ones_like(x, dtype=xp.bool), k=k)
     x_mask_flat = xp.reshape(x_mask, -1)
     x_flat = xp.reshape(x, -1)
@@ -108,7 +108,7 @@ def _energy_distance_from_distance_matrices(
             an EstimationStatistic enum instance.
 
     """
-    xp = get_namespace(distance_xx, distance_yy, distance_xy)
+    xp = array_namespace(distance_xx, distance_yy, distance_xy)
 
     if isinstance(estimation_stat, str):
         estimation_stat = EstimationStatistic.from_string(estimation_stat)

--- a/dcor/_hypothesis.py
+++ b/dcor/_hypothesis.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Generic, Iterator, TypeVar
 import numpy as np
 from joblib import Parallel, delayed
 
-from ._utils import ArrayType, RandomLike, _random_state_init, get_namespace
+from ._utils import ArrayType, RandomLike, _random_state_init, array_namespace
 
 T = TypeVar("T", bound=ArrayType)
 
@@ -51,7 +51,7 @@ def _permuted_statistic(
     permutation: np.typing.NDArray[int],
 ) -> T:
 
-    xp = get_namespace(matrix)
+    xp = array_namespace(matrix)
 
     # We implicitly convert to NumPy for permuting the array if we don't
     # have a take function.
@@ -92,7 +92,7 @@ def _permutation_test_with_sym_matrix(
         Results of the hypothesis test.
 
     """
-    xp = get_namespace(matrix)
+    xp = array_namespace(matrix)
     matrix = xp.asarray(matrix)
     random_state = _random_state_init(random_state)
 

--- a/dcor/_rowwise.py
+++ b/dcor/_rowwise.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from . import _dcor
 from ._fast_dcov_avl import _rowwise_distance_covariance_sqr_avl_generic
-from ._utils import ArrayType, RowwiseMode as RowwiseMode, _sqrt, get_namespace
+from ._utils import ArrayType, RowwiseMode as RowwiseMode, _sqrt, array_namespace
 
 Array = TypeVar("Array", bound=ArrayType)
 
@@ -186,7 +186,7 @@ def rowwise(
         raise NotImplementedError(
             "There is not an optimized rowwise implementation")
 
-    xp = get_namespace(x, y)
+    xp = array_namespace(x, y)
 
     return xp.asarray(
         [function(x_elem, y_elem, **kwargs) for x_elem, y_elem in zip(x, y)],

--- a/dcor/distances.py
+++ b/dcor/distances.py
@@ -13,7 +13,7 @@ from typing import TypeVar
 import numpy as np
 import scipy.spatial as spatial
 
-from dcor._utils import ArrayType, _sqrt, _transform_to_2d, get_namespace
+from dcor._utils import ArrayType, _sqrt, _transform_to_2d, array_namespace
 
 from ._utils import _can_be_numpy_double
 
@@ -22,7 +22,7 @@ Array = TypeVar("Array", bound=ArrayType)
 
 def _cdist_naive(x: Array, y: Array, exponent: float = 1) -> Array:
     """Pairwise distance, custom implementation."""
-    xp = get_namespace(x, y)
+    xp = array_namespace(x, y)
 
     x = xp.asarray(x)
     y = xp.asarray(y)

--- a/dcor/homogeneity.py
+++ b/dcor/homogeneity.py
@@ -20,7 +20,7 @@ from ._energy import (
     energy_distance,
 )
 from ._hypothesis import HypothesisTest, _permutation_test_with_sym_matrix
-from ._utils import ArrayType, RandomLike, _transform_to_2d, get_namespace
+from ._utils import ArrayType, RandomLike, _transform_to_2d, array_namespace
 
 Array = TypeVar("Array", bound=ArrayType)
 
@@ -249,7 +249,7 @@ def energy_test(
 
     sample_sizes = tuple(a.shape[0] for a in samples)
 
-    xp = get_namespace(*samples)
+    xp = array_namespace(*samples)
 
     # NumPy namespace has no concat function yet
     try:

--- a/dcor/independence.py
+++ b/dcor/independence.py
@@ -196,21 +196,17 @@ def partial_distance_covariance_test(
         >>> dcor.independence.partial_distance_covariance_test(a, a, b)
         ...                                       # doctest: +ELLIPSIS
         HypothesisTest(pvalue=1.0, statistic=142.6664416...)
-        >>> dcor.independence.partial_distance_covariance_test(a, b, c)
-        ...                                      # doctest: +ELLIPSIS
-        HypothesisTest(pvalue=1.0, statistic=7.0791037...e-15)
-        >>> dcor.independence.partial_distance_covariance_test(b, b, c)
-        ...                                      # doctest: +ELLIPSIS
-        HypothesisTest(pvalue=1.0, statistic=6.3170502...e-31)
-        >>> dcor.independence.partial_distance_covariance_test(a, b, c,
+        >>> test = dcor.independence.partial_distance_covariance_test(a, b, c)
+        >>> test.pvalue # doctest: +ELLIPSIS
+        1.0
+        >>> np.allclose(test.statistic, 0, atol=1e-6)
+        True
+        >>> test = dcor.independence.partial_distance_covariance_test(a, b, c,
         ... num_resamples=5, random_state=0)
-        HypothesisTest(pvalue=0.1666666..., statistic=7.0791037...e-15)
-        >>> dcor.independence.partial_distance_covariance_test(a, b, c,
-        ... num_resamples=5, random_state=13)
-        HypothesisTest(pvalue=0.1666666..., statistic=7.0791037...e-15)
-        >>> dcor.independence.partial_distance_covariance_test(a, c, b,
-        ... num_resamples=7, random_state=0)
-        HypothesisTest(pvalue=1.0, statistic=-7.5701764...e-12)
+        >>> test.pvalue # doctest: +ELLIPSIS
+        0.1666666...
+        >>> np.allclose(test.statistic, 0, atol=1e-6)
+        True
 
     """
     random_state = _random_state_init(random_state)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,8 @@ import sys
 import pkg_resources
 # Patch sphinx_gallery.binder.gen_binder_rst so as to point to .py file in
 # repository
-import sphinx_gallery.binder
+import sphinx_gallery.gen_rst
+import sphinx_gallery.interactive_example
 
 try:
     release = pkg_resources.get_distribution('dcor').version
@@ -277,7 +278,7 @@ autodoc_typehints = "description"
 # Binder integration
 # Taken from
 # https://stanczakdominik.github.io/posts/simple-binder-usage-with-sphinx-gallery-through-jupytext/
-original_gen_binder_rst = sphinx_gallery.binder.gen_binder_rst
+original_gen_binder_rst = sphinx_gallery.interactive_example.gen_binder_rst
 
 
 def patched_gen_binder_rst(*args, **kwargs):
@@ -293,4 +294,5 @@ def patched_gen_binder_rst(*args, **kwargs):
 #  # And then we finish our monkeypatching misdeed by redirecting
 
 # sphinx-gallery to use our function:
-sphinx_gallery.binder.gen_binder_rst = patched_gen_binder_rst
+sphinx_gallery.interactive_example.gen_binder_rst = patched_gen_binder_rst
+sphinx_gallery.gen_rst.gen_binder_rst = patched_gen_binder_rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,11 @@ classifiers = [
 dynamic = ["version"]
 
 dependencies = [
-  "numpy",
-  "numba>=0.51",
-  "scipy",
+  "array-api-compat",
   "joblib",
+  "numba>=0.51",
+  "numpy",
+  "scipy",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Use array_api_compat.

- Fix a bug due to the removal of np.bool.
- Allow to use NumPy, CuPy and Tensorflow NOW.