### PR TITLE
Fix issue 59.

### DIFF
--- a/dcor/_dcor_internals.py
+++ b/dcor/_dcor_internals.py
@@ -184,8 +184,8 @@ def _dcov_from_terms(
 ) -> Array:
     """Compute distance covariance WITHOUT centering first."""
     first_term = mean_prod / n_samples
-    second_term = a_axis_sum @ b_axis_sum / n_samples
-    third_term = a_total_sum * b_total_sum / n_samples
+    second_term = a_axis_sum / n_samples @ b_axis_sum
+    third_term = a_total_sum / n_samples * b_total_sum
 
     if bias_corrected:
         first_term /= (n_samples - 3)

--- a/dcor/tests/test_dcor.py
+++ b/dcor/tests/test_dcor.py
@@ -523,14 +523,17 @@ class TestDistanceCorrelation(unittest.TestCase):
         int_int = dcor.distance_correlation(
             arr1,
             arr2,
+            compile_mode=dcor.CompileMode.NO_COMPILE,
         )
         float_int = dcor.distance_correlation(
             arr1.astype(float),
             arr2,
+            compile_mode=dcor.CompileMode.NO_COMPILE,
         )
         int_float = dcor.distance_correlation(
             arr1,
             arr2.astype(float),
+            compile_mode=dcor.CompileMode.NO_COMPILE,
         )
         float_float = dcor.distance_correlation(
             arr1.astype(float),

--- a/dcor/tests/test_dcor.py
+++ b/dcor/tests/test_dcor.py
@@ -517,8 +517,8 @@ class TestDistanceCorrelation(unittest.TestCase):
         n_samples = 10000
 
         # some simple data
-        arr1 = np.array([1, 2, 3] * n_samples)
-        arr2 = np.array([10, 20, 5] * n_samples)
+        arr1 = np.array([1, 2, 3] * n_samples, dtype=np.int32)
+        arr2 = np.array([10, 20, 5] * n_samples, dtype=np.int32)
 
         int_int = dcor.distance_correlation(
             arr1,

--- a/dcor/tests/test_dcor.py
+++ b/dcor/tests/test_dcor.py
@@ -512,6 +512,35 @@ class TestDistanceCorrelation(unittest.TestCase):
         corr_af_inv = dcor.distance_correlation_af_inv(a, a)
         self.assertAlmostEqual(corr_af_inv, 0)
 
+    def test_integer_overflow(self) -> None:
+        """Tests int overflow behavior detected in issue #59."""
+        n_samples = 10000
+
+        # some simple data
+        arr1 = np.array([1, 2, 3] * n_samples)
+        arr2 = np.array([10, 20, 5] * n_samples)
+
+        int_int = dcor.distance_correlation(
+            arr1,
+            arr2,
+        )
+        float_int = dcor.distance_correlation(
+            arr1.astype(float),
+            arr2,
+        )
+        int_float = dcor.distance_correlation(
+            arr1,
+            arr2.astype(float),
+        )
+        float_float = dcor.distance_correlation(
+            arr1.astype(float),
+            arr2.astype(float),
+        )
+
+        self.assertAlmostEqual(int_int, float_float)
+        self.assertAlmostEqual(float_int, float_float)
+        self.assertAlmostEqual(int_float, float_float)
+
 
 class TestDcorArrayAPI(unittest.TestCase):
     """Check that the energy distance works with the Array API standard."""

--- a/dcor/tests/test_dcor.py
+++ b/dcor/tests/test_dcor.py
@@ -517,8 +517,8 @@ class TestDistanceCorrelation(unittest.TestCase):
         n_samples = 10000
 
         # some simple data
-        arr1 = np.array([1, 2, 3] * n_samples, dtype=np.int32)
-        arr2 = np.array([10, 20, 5] * n_samples, dtype=np.int32)
+        arr1 = np.array([1, 2, 3] * n_samples, dtype=np.int64)
+        arr2 = np.array([10, 20, 5] * n_samples, dtype=np.int64)
 
         int_int = dcor.distance_correlation(
             arr1,


### PR DESCRIPTION
Fixes #59, caused by an integer overflow, by reordering the operands, so that the data is first converted to a floating type.

Adds a test for this behavior.