### PR TITLE
Don't omit dcor/tests from pytest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Run tests
       run: |
         pip3 install ".[test]"
-        coverage run --source=dcor/ --omit=dcor/tests/ -m pytest
+        coverage run --source=dcor/ -m pytest
     
     - name: Generate coverage XML
       run: |


### PR DESCRIPTION
The CI test running command with coverage had a flag to omit dcor/tests.  

I've only tried a single run, but the tests still pass without it (on all 3 OSs , Python 3.10-3.12) so shouldn't this option be removed?  

What's the point in going to the effort of having lots of great tests, and setting up a Continuous Integration system, only to have it omit most of those tests?  

Maybe someone left it there accidentally after they were trying something out.