### PR TITLE
Python 3.13 support.  Monkey patches doctest in conftest.py, so doctests pass against both numpy 1 and numpy 2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Run tests
       run: |
         pip3 install ".[test]"
-        coverage run --source=dcor/ --omit=dcor/tests/ -m pytest
+        coverage run --source=dcor/ -m pytest
     
     - name: Generate coverage XML
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Run tests
       run: |
         pip3 install ".[test]"
-        coverage run --source=dcor/ -m pytest
+        coverage run --source=dcor/ --omit=dcor/tests/ -m pytest
     
     - name: Generate coverage XML
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Run tests
       run: |
         pip3 install ".[test]"
-        coverage run --source=dcor/ --omit=dcor/tests/ -m pytest
+        coverage run --source=dcor/ --omit=dcor/tests/ -m pytest --doctest-glob=""
     
     - name: Generate coverage XML
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Run tests
       run: |
         pip3 install ".[test]"
-        coverage run --source=dcor/ --omit=dcor/tests/ -m pytest --doctest-glob=""
+        coverage run --source=dcor/ --omit=dcor/tests/ -m pytest
     
     - name: Generate coverage XML
       run: |

--- a/conftest.py
+++ b/conftest.py
@@ -1,13 +1,39 @@
+
+import doctest
+
 collect_ignore = ['setup.py']
 
 pytest_plugins = ("pytest_cov", "subtests")
 
 
+doctest_normal_output_checker = doctest.OutputChecker
+
+class Numpy1Numpy2AgnosticOutputChecker(doctest.OutputChecker):
+
+
+    def numpy_doctest_output_fix(self, want, got, optionflags):
+        if want == got:
+            return True
+        if want == f'np.float64({got})':
+            return True
+
+
+
+        return False
+
+
+
 def pytest_configure(config):
     import sys
     sys._called_from_test = True
+    doctest.OutputChecker = Numpy1Numpy2AgnosticOutputChecker
+
 
 
 def pytest_unconfigure(config):
     import sys
     del sys._called_from_test
+    doctest.OutputChecker = doctest_normal_output_checker
+
+
+

--- a/conftest.py
+++ b/conftest.py
@@ -10,20 +10,24 @@ pytest_plugins = ("pytest_cov", "subtests")
 OutputChecker = doctest.OutputChecker
 
 
+numpy2_float64_pattern = r'np\.float64\((?P<num>inf|[+-]?\d*\.\d+)\)'
+
+def ensure_numpy_1_style_repr(repr_: str)-> str:
+    return re.sub(
+                numpy2_float64_pattern,
+                lambda m: m['num'],
+                repr_,
+                )
+
 
 class Numpy1Numpy2AgnosticOutputChecker(doctest.OutputChecker):
 
-    numpy2_float64_pattern = r'np\.float64\((?P<num>inf|[+-]?\d*\.\d+)\)'
-    
     def check_output(self, want, got, optionflags):
 
-        numpy_1_style_got = re.sub(
-                self.numpy2_float64_pattern,
-                lambda m: m['num'],
-                got,
-                )
+        numpy_1_style_want = ensure_numpy_1_style_repr(want)
+        numpy_1_style_got = ensure_numpy_1_style_repr(got)
 
-        return super().check_output(want, numpy_1_style_got, optionflags)
+        return super().check_output(numpy_1_style_want, numpy_1_style_got, optionflags)
 
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+# type: ignore
 import re
 import doctest
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-
+import re
 import doctest
 
 collect_ignore = ['setup.py']
@@ -6,20 +6,24 @@ collect_ignore = ['setup.py']
 pytest_plugins = ("pytest_cov", "subtests")
 
 
-doctest_normal_output_checker = doctest.OutputChecker
+OutputChecker = doctest.OutputChecker
+
+
 
 class Numpy1Numpy2AgnosticOutputChecker(doctest.OutputChecker):
 
+    numpy2_float64_pattern = r'np\.float64\((?P<num>inf|[+-]?\d*\.\d+)\)'
+    
+    def check_output(self, want, got, optionflags):
 
-    def numpy_doctest_output_fix(self, want, got, optionflags):
-        if want == got:
-            return True
-        if want == f'np.float64({got})':
-            return True
+        numpy_1_style_got = re.sub(
+                self.numpy2_float64_pattern,
+                lambda m: m['num'],
+                got,
+                )
 
+        return super().check_output(want, numpy_1_style_got, optionflags)
 
-
-        return False
 
 
 
@@ -33,7 +37,7 @@ def pytest_configure(config):
 def pytest_unconfigure(config):
     import sys
     del sys._called_from_test
-    doctest.OutputChecker = doctest_normal_output_checker
+    doctest.OutputChecker = OutputChecker
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ docs = [
 ]
 test = [
   "array-api-strict",
-  "numpy<2", # NumPy 2 changes array repr, affecting doctests.
+  "numpy", 
   "pytest",
   "pytest-cov",
   "pytest-subtests",


### PR DESCRIPTION
<!--
Thanks for your contribution! Please ensure you have taken a look at
the contribution guidelines:
https://github.com/vnmabus/dcor/blob/develop/CONTRIBUTING.md
-->

## Describe the proposed changes

 - Relaxes the `numpy <2` pin in the optional test dependencies (in pyproject.toml).
 - In conftest.py, swap out doctest.OutputChecker for a sub class of it that does not fail when
   floating points (inc "inf") are wrapped by "np.float64(...)"
 - In .github\workflows\main.yml add Python 3.13 to the test matrix.

## Additional information
- Tested in CI and locally.

## Checklist before requesting a review

- [X ] I have performed a self-review of my code
```
>uvx ruff check conftest.py
All checks passed!
```
- [X ] The code conforms to the style used in this package
No code style tools are being run in CI. I couldn't find any style guidance elsewhere.  Nothing is mentioned in CONTRIBUTING.md.  But it's a concise change that's loosely PEP8 compliant, and only changes test code.

- [X ] The code is fully documented and typed (type-checked with [Mypy](https://mypy-lang.org/))
The entire point of the code in conftest.py is to carry out monkey patching. This relies on Python's dynamic typing, and is 
more trouble than it is worth to statically type.  It is also just there to run the tests, so needn't be perfect.  Therefore
I have added #type: ignore to the top of it.

FYI Running mypy on the rest of the project shows that it does not pass type checking anyway: 
```
uvx mypy .
...
Found 219 errors in 25 files (checked 30 source files)
```
I'll gladly help fix those, if further PRs to that end will be accepted.  But these 'errors' have nothing to do with this PR.

- [X ] I have added thorough tests for the new/changed functionality
Extending the Python versions that the tests are run on (while avoiding spurious failures due to breaking changes in Numpy) is the entire goal of this PR.