### PR TITLE
env variable for disabling fs cache

### DIFF
--- a/dcor/_dcor_internals_numba.py
+++ b/dcor/_dcor_internals_numba.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable
-import os
 
 import numba
 import numpy as np
@@ -9,11 +8,11 @@ from numba import boolean, float64, int64
 from numba.types import Array, Tuple
 
 from ._dcor_internals import _dcov_from_terms
+from ._utils import FS_CACHE
 
 if TYPE_CHECKING:
     import numpy.typing
 
-FS_CACHE = False if os.environ.get("DCOR_DISABLE_FS_CACHE") else True
 
 NumbaVector = Array(dtype=float64, ndim=1, layout="C")
 NumbaVectorReadOnly = Array(dtype=float64, ndim=1, layout="C", readonly=True)

--- a/dcor/_dcor_internals_numba.py
+++ b/dcor/_dcor_internals_numba.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable
+import os
 
 import numba
 import numpy as np
@@ -12,6 +13,7 @@ from ._dcor_internals import _dcov_from_terms
 if TYPE_CHECKING:
     import numpy.typing
 
+FS_CACHE = False if os.environ.get("DCOR_DISABLE_FS_CACHE") else True
 
 NumbaVector = Array(dtype=float64, ndim=1, layout="C")
 NumbaVectorReadOnly = Array(dtype=float64, ndim=1, layout="C", readonly=True)
@@ -36,7 +38,7 @@ _dcov_from_terms_compiled = numba.njit(
         int64,
         boolean,
     ),
-    cache=True,
+    cache=FS_CACHE,
 )(_dcov_from_terms)
 
 

--- a/dcor/_fast_dcov_avl.py
+++ b/dcor/_fast_dcov_avl.py
@@ -14,7 +14,6 @@ from typing import (
     TypeVar,
     overload,
 )
-import os
 
 import numba
 import numpy as np
@@ -30,14 +29,13 @@ from ._dcor_internals_numba import (
     NumbaVectorReadOnlyNonContiguous,
     _generate_distance_covariance_sqr_from_terms_impl,
 )
-from ._utils import CompileMode, _transform_to_1d
+from ._utils import CompileMode, _transform_to_1d, FS_CACHE
 
 if TYPE_CHECKING:
     NumpyArrayType = np.typing.NDArray[np.number[Any]]
 else:
     NumpyArrayType = np.ndarray
 
-FS_CACHE = False if os.environ.get("DCOR_DISABLE_FS_CACHE") else True
 
 Array = TypeVar("Array", bound=NumpyArrayType)
 

--- a/dcor/_fast_dcov_avl.py
+++ b/dcor/_fast_dcov_avl.py
@@ -14,6 +14,7 @@ from typing import (
     TypeVar,
     overload,
 )
+import os
 
 import numba
 import numpy as np
@@ -36,6 +37,7 @@ if TYPE_CHECKING:
 else:
     NumpyArrayType = np.ndarray
 
+FS_CACHE = False if os.environ.get("DCOR_DISABLE_FS_CACHE") else True
 
 Array = TypeVar("Array", bound=NumpyArrayType)
 
@@ -141,7 +143,7 @@ _dyad_update_compiled = numba.njit(
         NumbaVector,
         NumbaIntVectorReadOnly,
     ),
-    cache=True,
+    cache=FS_CACHE,
 )(
     _dyad_update_compiled_version,
 )
@@ -193,7 +195,7 @@ _partial_sum_2d_compiled = numba.njit(
         NumbaIntVectorReadOnly,
         NumbaVector,
     ),
-    cache=True,
+    cache=FS_CACHE,
 )(
     _generate_partial_sum_2d(compiled=True),
 )
@@ -303,7 +305,7 @@ _get_impl_args_compiled = numba.njit(
         NumbaIntVectorReadOnly,
         NumbaMatrix,
     ))(NumbaVectorReadOnlyNonContiguous, NumbaVectorReadOnlyNonContiguous),
-    cache=True,
+    cache=FS_CACHE,
 )(_get_impl_args)
 
 
@@ -429,7 +431,7 @@ _distance_covariance_sqr_terms_avl_impl_compiled = numba.njit(
         numba.optional(float64),
         numba.optional(float64),
     ))(NumbaVectorReadOnlyNonContiguous, NumbaVectorReadOnlyNonContiguous, boolean),
-    cache=True,
+    cache=FS_CACHE,
 )(
     _generate_distance_covariance_sqr_terms_avl_impl(compiled=True),
 )
@@ -446,7 +448,7 @@ _distance_covariance_sqr_avl_impl_compiled = numba.njit(
         NumbaVectorReadOnlyNonContiguous,
         boolean,
     ),
-    cache=True,
+    cache=FS_CACHE,
 )(
     _generate_distance_covariance_sqr_from_terms_impl(
         compiled=True,
@@ -582,7 +584,7 @@ def _generate_rowwise_internal(
         )],
         '(n),(n),()->()',
         nopython=True,
-        cache=True,
+        cache=FS_CACHE,
         target=target,
     )(_rowwise_distance_covariance_sqr_avl_generic_internal)
 

--- a/dcor/_fast_dcov_mergesort.py
+++ b/dcor/_fast_dcov_mergesort.py
@@ -13,7 +13,6 @@ from typing import (
     TypeVar,
     overload,
 )
-import os
 
 import numba
 import numpy as np
@@ -28,14 +27,12 @@ from ._dcor_internals_numba import (
     NumbaVectorReadOnlyNonContiguous,
     _generate_distance_covariance_sqr_from_terms_impl,
 )
-from ._utils import CompileMode, _transform_to_1d
+from ._utils import CompileMode, _transform_to_1d, FS_CACHE
 
 if TYPE_CHECKING:
     NumpyArrayType = np.typing.NDArray[np.number[Any]]
 else:
     NumpyArrayType = np.ndarray
-
-FS_CACHE = False if os.environ.get("DCOR_DISABLE_FS_CACHE") else True
 
 Array = TypeVar("Array", bound=NumpyArrayType)
 

--- a/dcor/_fast_dcov_mergesort.py
+++ b/dcor/_fast_dcov_mergesort.py
@@ -13,6 +13,7 @@ from typing import (
     TypeVar,
     overload,
 )
+import os
 
 import numba
 import numpy as np
@@ -33,6 +34,8 @@ if TYPE_CHECKING:
     NumpyArrayType = np.typing.NDArray[np.number[Any]]
 else:
     NumpyArrayType = np.ndarray
+
+FS_CACHE = False if os.environ.get("DCOR_DISABLE_FS_CACHE") else True
 
 Array = TypeVar("Array", bound=NumpyArrayType)
 
@@ -132,7 +135,7 @@ def _compute_weight_sums(
 
 _compute_weight_sums_compiled = numba.njit(
     NumbaMatrix(NumbaVectorReadOnly, NumbaMatrixReadOnly),
-    cache=True,
+    cache=FS_CACHE,
 )(_compute_weight_sums)
 
 
@@ -179,7 +182,7 @@ def _generate_compute_aijbij_term(
 _compute_aijbij_term = _generate_compute_aijbij_term(compiled=False)
 _compute_aijbij_term_compiled = numba.njit(
     float64(NumbaVectorReadOnly, NumbaVectorReadOnly),
-    cache=True,
+    cache=FS_CACHE,
 )(
     _generate_compute_aijbij_term(
         compiled=True,
@@ -205,7 +208,7 @@ def _compute_row_sums(
 
 _compute_row_sums_compiled = numba.njit(
     NumbaVector(NumbaVectorReadOnly),
-    cache=True)(_compute_row_sums)
+    cache=FS_CACHE)(_compute_row_sums)
 
 
 def _generate_distance_covariance_sqr_terms_mergesort_impl(
@@ -285,7 +288,7 @@ _distance_covariance_sqr_terms_mergesort_impl_compiled = numba.njit(
         NumbaVectorReadOnlyNonContiguous,
         boolean,
     ),
-    cache=True,
+    cache=FS_CACHE,
 )(
     _generate_distance_covariance_sqr_terms_mergesort_impl(
         compiled=True,
@@ -306,7 +309,7 @@ _distance_covariance_sqr_mergesort_generic_impl_compiled = numba.njit(
         NumbaVectorReadOnlyNonContiguous,
         boolean,
     ),
-    cache=True,
+    cache=FS_CACHE,
 )(
     _generate_distance_covariance_sqr_from_terms_impl(
         compiled=True,

--- a/dcor/_utils.py
+++ b/dcor/_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import enum
 import warnings
 from typing import TYPE_CHECKING, Any, Iterable, TypeVar, Union
+import os
 
 import numpy as np
 from array_api_compat import (
@@ -25,6 +26,8 @@ RandomLike = Union[
     int,
     None,
 ]
+
+FS_CACHE = False if os.environ.get("DCOR_DISABLE_FS_CACHE") else True
 
 
 class CompileMode(enum.Enum):


### PR DESCRIPTION
## References to issues or other PRs
Quick change. No issues opened. I am fighting through the filesystem cache that numba generates. I would like to have it disabled. Please merge if you don't mind. Currently it's a hardcoded `yes` that cannot be configured.

## Describe the proposed changes
Add an env var `DCOR_DISABLE_FS_CACHE`. When set the filesystem cache is disabled.

## Additional information
None

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [?] The code conforms to the style used in this package
- [x] The code is fully documented and typed (type-checked with [Mypy](https://mypy-lang.org/))
- [-] I have added thorough tests for the new/changed functionality